### PR TITLE
Fix USA focus tree

### DIFF
--- a/Cold War Iron Curtain/common/national_focus/USA_1950s.txt
+++ b/Cold War Iron Curtain/common/national_focus/USA_1950s.txt
@@ -2110,6 +2110,7 @@ focus_tree = {
 		x = 16
 		y = 8
 		completion_reward = {
+			ISR = {
 					random_owned_controlled_state = {
 							limit = {
 									free_building_slots = {
@@ -2175,6 +2176,7 @@ focus_tree = {
 						
 					}
 				}
+			}
 	}
 	focus = {
 		id = USA_support_honduras_coup
@@ -2250,6 +2252,7 @@ focus_tree = {
 		x = 19
 		y = 2
 		completion_reward = {
+			KOR = {
 					random_owned_controlled_state = {
 							limit = {
 									free_building_slots = {
@@ -2315,6 +2318,7 @@ focus_tree = {
 						
 					}
 				}
+			}
 	}
 	focus = {
 		id = USA_defend_the_border
@@ -2885,7 +2889,7 @@ focus_tree = {
 				name = land_doc_bonus
 				bonus = 0.5
 				uses = 2
-				category = land_doctrine
+				category = air_doctrine
 			}
 		}
 	}


### PR DESCRIPTION
Two support economy focuses gave factories to USA instead of target countries.

Reform doctrine focus in air focus tree gave research bonus to land doctrines instead of (probably intended) air doctrines.