### PR TITLE
Change transport's category to heavy_air

### DIFF
--- a/Cold War Iron Curtain/common/technologies/air_techs.txt
+++ b/Cold War Iron Curtain/common/technologies/air_techs.txt
@@ -3799,7 +3799,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 			
 		}
@@ -3829,7 +3829,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 			
 		}
@@ -3859,7 +3859,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -3888,7 +3888,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -3917,7 +3917,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -3946,7 +3946,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -3979,7 +3979,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -4008,7 +4008,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -4037,7 +4037,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		
@@ -4061,7 +4061,7 @@ technologies = {
 		}
 		
 		categories = {
-			light_air
+			heavy_air
 			transport_air
 		}
 		


### PR DESCRIPTION
The equipment is located in quad_engine_airframe.txt - with other heavy planes so it would seem that "light_air" category is an error.