### PR TITLE
Change USA focuses giving research bonuses

### DIFF
--- a/Cold War Iron Curtain/common/national_focus/USA_1950s.txt
+++ b/Cold War Iron Curtain/common/national_focus/USA_1950s.txt
@@ -274,9 +274,7 @@ focus_tree = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 				}
@@ -293,12 +291,9 @@ focus_tree = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = paratroopers
-							technology = paratroopers2
-							technology = marines
-							technology = marines2
-							technology = tech_mountaineers
-							technology = tech_mountaineers2
+							category = para_tech
+							category = marine_tech
+							category = mountaineers_tech
 						}
 				}
 	}
@@ -2818,8 +2813,7 @@ focus_tree = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = tech_mountaineers
-							technology = tech_mountaineers2
+							category = mountaineers_tech
 						}
 				}
 	}
@@ -2908,13 +2902,7 @@ focus_tree = {
 							name = fighter_bonus
 							bonus = 0.5
 							uses = 2
-							technology = early_fighter
-							technology = fighter1
-							technology = fighter2
-							technology = fighter3
-							technology = heavy_fighter1
-							technology = heavy_fighter2
-							technology = heavy_fighter3
+							category = light_air
 						}
 				}
 	}
@@ -2933,8 +2921,7 @@ focus_tree = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = marines
-							technology = marines2
+							category = marine_tech
 						}
 				}
 	}
@@ -2953,9 +2940,7 @@ focus_tree = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = paratroopers
-							technology = paratroopers2
-
+							category = para_tech
 						}
 				}
 	}
@@ -2980,12 +2965,9 @@ focus_tree = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = paratroopers
-							technology = paratroopers2
-							technology = marines
-							technology = marines2
-							technology = tech_mountaineers
-							technology = tech_mountaineers2
+							category = para_tech
+							category = marine_tech
+							category = mountaineers_tech
 						}
 				}
 	}
@@ -3035,9 +3017,7 @@ focus_tree = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 				}
@@ -3477,10 +3457,7 @@ focus_tree = {
 				ahead_reduction = 1
 				uses = 1
 				technology = battle_cruiser_2
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 	}
@@ -3502,12 +3479,7 @@ focus_tree = {
 				ahead_reduction = 1
 				uses = 1
 				technology = battle_cruiser_2
-				
-				
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 	}
@@ -3531,12 +3503,7 @@ focus_tree = {
 				ahead_reduction = 1
 				uses = 1
 				technology = battle_cruiser_2
-				
-				
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 


### PR DESCRIPTION
Give bonus for whole category, rather than specific technologies (with the exception of battle_cruiser when it would allow to research 1980 tech without ahead-of-time penalties) to make the focuses more useful. Previously, most bonuses applied only to already researched techs (for example fighter bonus did not apply to jet_fighters).