### PR TITLE
Change USSR focuses giving research bonuses

### DIFF
--- a/Cold War Iron Curtain/common/national_focus/soviet_cold_war_focus.txt
+++ b/Cold War Iron Curtain/common/national_focus/soviet_cold_war_focus.txt
@@ -408,22 +408,14 @@ focus_tree = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 						add_tech_bonus = {
 							name = fighter_bonus
 							bonus = 0.5
 							uses = 2
-							technology = early_fighter
-							technology = fighter1
-							technology = fighter2
-							technology = fighter3
-							technology = heavy_fighter1
-							technology = heavy_fighter2
-							technology = heavy_fighter3
+							category = light_air
 						}
 		}
 
@@ -3066,8 +3058,7 @@ completion_reward = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = paratroopers
-							technology = paratroopers2
+							category = para_tech
 						}
 					}
 	}
@@ -3085,8 +3076,7 @@ completion_reward = {
 							name = special_forces_bonus
 							bonus = 0.5
 							uses = 1
-							technology = paratroopers
-							technology = paratroopers2
+							category = para_tech
 						}
 					}
 	}
@@ -3382,7 +3372,7 @@ completion_reward = {
 					add_tech_bonus = {
 							name = motorized_bonus
 							bonus = 0.75
-							technology = motorised_infantry
+							category = cat_mechanized_equipment
 						}
 				}
 	}
@@ -3430,9 +3420,7 @@ completion_reward = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 				}
@@ -4388,15 +4376,13 @@ completion_reward = {
 				name = bb_bonus
 				bonus = 0.5
 				uses = 2
+				category = bb_tech
 			}
 			add_tech_bonus = {
 				name = cr_bonus
 				bonus = 0.5
 				uses = 2
-				technology = improved_light_cruiser
-				
-				
-				
+				category = cl_tech
 			}
 		}
 	}
@@ -4511,10 +4497,7 @@ completion_reward = {
 				name = cv_bonus
 				bonus = 0.5
 				uses = 2
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 	}
@@ -4535,10 +4518,7 @@ completion_reward = {
 				ahead_reduction = 1
 				uses = 1
 				technology = battle_cruiser_2
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 	}
@@ -4700,10 +4680,7 @@ completion_reward = {
 				ahead_reduction = 1
 				uses = 1
 				technology = battle_cruiser_2
-				technology = early_carrier
-				technology = basic_carrier
-				technology = improved_carrier
-				technology = advanced_carrier
+				category = cv_tech
 			}
 		}
 	}
@@ -7839,9 +7816,7 @@ completion_reward = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 				}
@@ -7915,9 +7890,7 @@ completion_reward = {
 							name = bomber_bonus
 							bonus = 0.5
 							uses = 2
-							technology = strategic_bomber1
-							technology = strategic_bomber2
-							technology = strategic_bomber3
+							category = cat_strategic_bomber
 							category = tactical_bomber
 						}
 				}
@@ -7936,7 +7909,7 @@ completion_reward = {
 							name = motorized_bonus
 							ahead_reduction = 0.5
 							uses = 2
-							category = motorized_equipment
+							category = cat_mechanized_equipment
 						}
 				}
 	}


### PR DESCRIPTION
Change specific techs to tech categories.

Change "motorized" to "mechanized" (as name of focus implies).

Add missing bonus for battleships.

I also feel that Russians should have sub research bonuses rather than CV-ones and have the CV bonus only in Air Carrier Initiative (which should also be called differently as they had "heavy aircraft-carrying missile cruisers" instead of "air carriers", which were a symbol of imperialism..)