### PR TITLE
Add all the new ship types to naval doctrines tech

### DIFF
--- a/Cold War Iron Curtain/common/technologies/naval_doctrine.txt
+++ b/Cold War Iron Curtain/common/technologies/naval_doctrine.txt
@@ -8,10 +8,19 @@ technologies = {
 		battleship = {
 			max_organisation = 10			
 		}
+		bbg = {
+			max_organisation = 10			
+		}
 		battle_cruiser = {
 			max_organisation = 10			
 		}
+		bcg = {
+			max_organisation = 10			
+		}
 		heavy_cruiser = {
+			max_organisation = 10			
+		}
+		cg = {
 			max_organisation = 10			
 		}
 		#####
@@ -65,14 +74,26 @@ technologies = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
 		}
+		bbg = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
 		battle_cruiser = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
+		bcg = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
 		}
 		heavy_cruiser = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
-		}		
+		}
+		cg = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
 		########
 
 		path = {
@@ -110,6 +131,15 @@ technologies = {
 		
 		# EFFECT #############
 		carrier = {
+			max_organisation = 10			
+		}
+		light_carrier = {
+			max_organisation = 10			
+		}
+		super_carrier = {
+			max_organisation = 10			
+		}
+		super_nuclear_carrier = {
 			max_organisation = 10			
 		}
 		sortie_efficiency = 0.1
@@ -150,7 +180,19 @@ technologies = {
 		#Groups of Destroyers (and CVEs should those ever be added) formed to hunt down enemy subs
 		
 		# EFFECT #############
+		frigate = {
+			max_organisation = 20
+			sub_detection = 0.2
+		}
+		ffg = {
+			max_organisation = 20
+			sub_detection = 0.2
+		}
 		destroyer = {
+			max_organisation = 20
+			sub_detection = 0.2
+		}
+		ddg = {
 			max_organisation = 20
 			sub_detection = 0.2
 		}
@@ -199,6 +241,9 @@ technologies = {
 		battleship = {
 			max_organisation = 20
 		}
+		bbg = {
+			max_organisation = 20
+		}
 		
 		navy_capital_ship_defence_factor = 0.10
 		
@@ -240,6 +285,15 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		sortie_efficiency = 0.1
 		########
 
@@ -280,12 +334,21 @@ technologies = {
 		battleship = {
 			max_organisation = 20
 		}
+		bbg = {
+			max_organisation = 20
+		}
 
 		battle_cruiser = {
 			max_organisation = 20
 		}
+		bcg = {
+			max_organisation = 20
+		}
 
 		heavy_cruiser = {
+			max_organisation = 20
+		}
+		cg = {
 			max_organisation = 20
 		}
 
@@ -320,7 +383,19 @@ technologies = {
 		#Convoy escort/ ASW branch
 		
 		# EFFECT #############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.1
 		}
@@ -362,7 +437,19 @@ technologies = {
 		#Assigning dedicated convoy escorts to keep them safe
 		
 		# EFFECT #############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.2
 		}
@@ -442,7 +529,16 @@ technologies = {
 		#The top convoy tech, basically now all the earlier concepts are working well with each other for maximum effect
 		
 		# EFFECT #############
+		frigate = {
+			max_organisation = 20
+		}
+		ffg = {
+			max_organisation = 20
+		}
 		destroyer = {
+			max_organisation = 20
+		}
+		ddg = {
 			max_organisation = 20
 		}
 		convoy_escort_efficiency = 0.25
@@ -487,6 +583,14 @@ technologies = {
 			max_organisation = 10
 			surface_detection = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+		}
 		#######
 
 		path = {
@@ -524,6 +628,14 @@ technologies = {
 
 		# EFFECT ##############
 		submarine = {
+			max_organisation = 10
+			surface_detection = 0.2
+		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.2
+		}
+		ballistic_submarine = {
 			max_organisation = 10
 			surface_detection = 0.2
 		}
@@ -568,6 +680,16 @@ technologies = {
 			surface_detection = 0.1
 			convoy_raiding_coordination = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
 		#######
 
 		path = {
@@ -608,6 +730,16 @@ technologies = {
 			surface_detection = 0.1
 			convoy_raiding_coordination = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
 		#######
 	
 		doctrine = yes	
@@ -643,12 +775,23 @@ technologies = {
 			max_organisation = 10
 			surface_detection = 0.1	
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1	
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1	
+		}
 
 		light_cruiser = {
 			max_organisation = 10
 			surface_detection = 0.1			
 		}
-
+		cg = {
+			max_organisation = 10
+			surface_detection = 0.1			
+		}
 		heavy_cruiser = {
 			max_organisation = 10
 			surface_detection = 0.1
@@ -709,6 +852,16 @@ technologies = {
 			surface_detection = 0.1
 			convoy_raiding_coordination = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
 		#######
 		
 		path = {
@@ -746,6 +899,14 @@ technologies = {
 		
 		# EFFECT ##############
 		submarine = {
+			surface_detection = 0.2
+			convoy_raiding_coordination = 0.1
+		}
+		nuclear_submarine = {
+			surface_detection = 0.2
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
 			surface_detection = 0.2
 			convoy_raiding_coordination = 0.1
 		}
@@ -791,6 +952,16 @@ technologies = {
 			convoy_raiding_coordination = 0.4
 			surface_detection = 0.25
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.4
+			surface_detection = 0.25
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.4
+			surface_detection = 0.25
+		}
 		#######
 		
 		path = {
@@ -828,6 +999,16 @@ technologies = {
 		
 		# EFFECT ##############
 		submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.4
+			surface_detection = 0.25
+		}
+		nuclear_submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.4
+			surface_detection = 0.25
+		}
+		ballistic_submarine = {
 			max_organisation = 10
 			convoy_raiding_coordination = 0.4
 			surface_detection = 0.25
@@ -873,13 +1054,27 @@ technologies = {
 			convoy_raiding_coordination = 0.1
 			surface_detection = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.1
+			surface_detection = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.1
+			surface_detection = 0.1
+		}
 
 		light_cruiser = {
 			max_organisation = 10
 			convoy_raiding_coordination = 0.7
 			surface_detection = 0.25
 		}
-
+		cg = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.7
+			surface_detection = 0.25
+		}
 		heavy_cruiser = {
 			max_organisation = 10
 			convoy_raiding_coordination = 0.7
@@ -887,6 +1082,11 @@ technologies = {
 		}
 
 		battle_cruiser = {
+			max_organisation = 10
+			convoy_raiding_coordination = 0.7
+			surface_detection = 0.25
+		}
+		bcg = {
 			max_organisation = 10
 			convoy_raiding_coordination = 0.7
 			surface_detection = 0.25
@@ -927,7 +1127,12 @@ technologies = {
 			convoy_raiding_coordination = 0.3
 			surface_detection = 0.25
 		}
-
+		cg = {
+			max_organisation = 10
+			surface_visibility = -0.25
+			convoy_raiding_coordination = 0.3
+			surface_detection = 0.25
+		}
 		heavy_cruiser = {
 			max_organisation = 10
 			surface_visibility = -0.25
@@ -941,8 +1146,20 @@ technologies = {
 			convoy_raiding_coordination = 0.3
 			surface_detection = 0.25
 		}
+		bcg = {
+			max_organisation = 10
+			surface_visibility = -0.25
+			convoy_raiding_coordination = 0.3
+			surface_detection = 0.25
+		}
 
 		battleship = {
+			max_organisation = 10
+			surface_visibility = -0.25
+			convoy_raiding_coordination = 0.3
+			surface_detection = 0.25
+		}
+		bbg = {
 			max_organisation = 10
 			surface_visibility = -0.25
 			convoy_raiding_coordination = 0.3
@@ -991,10 +1208,22 @@ technologies = {
 			convoy_raiding_coordination = 0.6
 			surface_detection = 0.25
 		}
+		bcg = {
+			max_organisation = 10
+			surface_visibility = -0.25
+			convoy_raiding_coordination = 0.6
+			surface_detection = 0.25
+		}
 
 		battleship = {
 			max_organisation = 10
 			surface_visibility = -0.5
+			convoy_raiding_coordination = 0.6
+			surface_detection = 0.25
+		}
+		bbg = {
+			max_organisation = 10
+			surface_visibility = -0.25
 			convoy_raiding_coordination = 0.6
 			surface_detection = 0.25
 		}
@@ -1038,7 +1267,15 @@ technologies = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
 		}
+		bbg = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
 		battle_cruiser = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
+		bcg = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
 		}
@@ -1046,6 +1283,10 @@ technologies = {
 			max_organisation = 10
 			search_and_destroy_coordination = 0.5
 		}		
+		cg = {
+			max_organisation = 10
+			search_and_destroy_coordination = 0.5
+		}
 		########
 		
 		path = {
@@ -1082,6 +1323,9 @@ technologies = {
 		#same as floating_fortress
 		# EFFECT #############
 		battleship = {
+			max_organisation = 20
+		}
+		bbg = {
 			max_organisation = 20
 		}
 		navy_capital_ship_defence_factor = 0.10
@@ -1123,6 +1367,15 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		sortie_efficiency = 0.1
 		########
 		
@@ -1157,6 +1410,15 @@ technologies = {
 		# EFFECT #############
 		carrier = {
 			max_organisation = 20
+		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
 		}
 		modifier = {
 			naval_strike_targetting_factor = 0.1
@@ -1197,7 +1459,19 @@ technologies = {
 
 		#same as convoy_sailing
 		# EFFECT #############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.1
 		}
@@ -1242,6 +1516,15 @@ technologies = {
 		carrier = {
 			max_organisation = 10			
 		}
+		light_carrier = {
+			max_organisation = 10			
+		}
+		super_carrier = {
+			max_organisation = 10			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 10			
+		}
 		sortie_efficiency = 0.1
 		########
 
@@ -1280,6 +1563,15 @@ technologies = {
 
 		# EFFECT #############
 		carrier = {
+			max_organisation = 10			
+		}
+		light_carrier = {
+			max_organisation = 10			
+		}
+		super_carrier = {
+			max_organisation = 10			
+		}
+		super_nuclear_carrier = {
 			max_organisation = 10			
 		}
 		modifier = {
@@ -1322,6 +1614,15 @@ technologies = {
 		# EFFECT ##############
 		carrier = {
 			max_organisation = 20
+		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
 		}
 		port_strike = 0.5
 		#####
@@ -1373,6 +1674,15 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		sortie_efficiency = 0.1
 
 		modifier = {
@@ -1416,7 +1726,22 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		light_cruiser = {
+			max_organisation = 20
+		}
+		cg = {
+			max_organisation = 20
+		}
+		heavy_cruiser = {
 			max_organisation = 20
 		}
 		modifier = {
@@ -1462,6 +1787,15 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		sortie_efficiency = 0.1
 		########
 
@@ -1499,6 +1833,15 @@ technologies = {
 		#CAGs are larger and more effort is made to have all planes arrive at the target at the same time, even when launched from multiple CVs
 		# EFFECT #############
 		carrier = {
+			max_organisation = 20			
+		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
 			max_organisation = 20			
 		}
 		carrier_capacity_penalty_reduction = -0.5
@@ -1547,6 +1890,9 @@ technologies = {
 		battleship = {
 			max_organisation = 20
 		}
+		bbg = {
+			max_organisation = 20
+		}
 		navy_capital_ship_defence_factor = 0.10
 		########
 
@@ -1586,7 +1932,22 @@ technologies = {
 		carrier = {
 			max_organisation = 20
 		}
+		light_carrier = {
+			max_organisation = 20			
+		}
+		super_carrier = {
+			max_organisation = 20			
+		}
+		super_nuclear_carrier = {
+			max_organisation = 20			
+		}
 		light_cruiser = {
+			max_organisation = 20
+		}
+		cg = {
+			max_organisation = 20
+		}
+		heavy_cruiser = {
 			max_organisation = 20
 		}
 
@@ -1628,6 +1989,14 @@ technologies = {
 			max_organisation = 10
 			surface_detection = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+		}
 		#######
 
 		path = {
@@ -1663,6 +2032,14 @@ technologies = {
 		# same as undersea_blockade
 		# EFFECT ##############
 		submarine = {
+			max_organisation = 10
+			surface_detection = 0.2
+		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.2
+		}
+		ballistic_submarine = {
 			max_organisation = 10
 			surface_detection = 0.2
 		}
@@ -1705,6 +2082,16 @@ technologies = {
 			surface_detection = 0.1
 			convoy_raiding_coordination = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
 		#######
 
 		path = {
@@ -1743,6 +2130,16 @@ technologies = {
 			surface_detection = 0.1
 			convoy_raiding_coordination = 0.1
 		}
+		nuclear_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
+		ballistic_submarine = {
+			max_organisation = 10
+			surface_detection = 0.1
+			convoy_raiding_coordination = 0.1
+		}
 		#######
 
 		doctrine = yes	
@@ -1772,7 +2169,19 @@ technologies = {
 
 		#same as convoy_escorts
 		# EFFECT #############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.2
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.2
 		}
@@ -1813,7 +2222,19 @@ technologies = {
 		# Lesser version of hunter-killer groups
 		
 		# EFFECT ##############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.1
 		}
@@ -1859,7 +2280,19 @@ technologies = {
 
 		#same as convoy_sailing
 		# EFFECT #############
+		frigate = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ffg = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
 		destroyer = {
+			max_organisation = 10
+			sub_detection = 0.1
+		}
+		ddg = {
 			max_organisation = 10
 			sub_detection = 0.1
 		}
@@ -1900,7 +2333,16 @@ technologies = {
 
 		#same as integrated_convoy_defence
 		# EFFECT #############
+		frigate = {
+			max_organisation = 20
+		}
+		ffg = {
+			max_organisation = 20
+		}
 		destroyer = {
+			max_organisation = 20
+		}
+		ddg = {
 			max_organisation = 20
 		}
 		convoy_escort_efficiency = 0.25


### PR DESCRIPTION
While it would be best to completely rework naval doctrines, I've made them usable at least.

No balancing changes were made - simply added new ship types to corresponding researches (so that it doesn't happen that standard carriers are much superior to the super carriers due to massive organization advantage after researching the doctrines).